### PR TITLE
Update polyfill.js

### DIFF
--- a/polyfill.js
+++ b/polyfill.js
@@ -3,8 +3,13 @@
 var implementation = require('./implementation');
 
 module.exports = function getPolyfill() {
-	if (typeof document === 'undefined') {
-		return implementation;
+	if (typeof document !== 'undefined') {
+		if (document.contains) {
+			return document.contains;
+		}
+		if (document.body && document.body.contains) {
+			return document.body.contains;
+		}
 	}
-	return document.contains || document.body.contains || implementation;
+	return implementation;
 };


### PR DESCRIPTION
Prevent Internet Explorer from throwing an exception  as its document does not have a body property.